### PR TITLE
fix: expand matching URLs for saved chat

### DIFF
--- a/packages/userscript/vite.config.ts
+++ b/packages/userscript/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
                 'namespace': packageJson.author,
                 'description': packageJson.description,
                 'license': packageJson.license,
-                'match': 'https://chat.openai.com/chat',
+                'match': ['https://chat.openai.com/chat', 'https://chat.openai.com/chat/*'],
                 'icon': 'https://chat.openai.com/favicon.ico',
                 'run-at': 'document-end',
             },


### PR DESCRIPTION
fixes #20

This was done to allow the script to execute on saved chats