### PR TITLE
docs: fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Install **Tampermonkey** **（[Chrome](https://www.tampermonkey.net/)** / **[Fir
 
 ## UserScript
 
-| Greasyfork                                                                         | GitHub                                                                                       |
-| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [Insatall](https://greasyfork.org/scripts/456055-chatgpt-exporter) | [Insatall](https://raw.githubusercontent.com/pionxzh/chatgpt-exporter/master/dist/chatgpt.user.js) |
+| Greasyfork                                                                        | GitHub                                                                                       |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [Install](https://greasyfork.org/scripts/456055-chatgpt-exporter) | [Install](https://raw.githubusercontent.com/pionxzh/chatgpt-exporter/master/dist/chatgpt.user.js) |
 
 # Example
 


### PR DESCRIPTION
Both install buttons were mistyped as "Insatall", they are now updated to be the proper spelling "Install".