### PR TITLE
fix: file name field styles in light mode

### DIFF
--- a/packages/userscript/src/menu.tsx
+++ b/packages/userscript/src/menu.tsx
@@ -51,7 +51,7 @@ export function Menu() {
                 Export
             </MenuItem>
             <Dropdown>
-            <fieldset className="inputFieldSet mb-2 rounded-md border-white/20 hover:bg-gray-500/10 duration-200">
+            <fieldset className="inputFieldSet mb-2 rounded-md text-white border-white/20 hover:bg-gray-500/10 duration-200">
                 <legend className="inputLabel px-2 text-xs">File Name: {'{title}, {timestamp}' }</legend>
                     <input
                         className="border-none text-sm w-full"


### PR DESCRIPTION
Before the tweak it looked like this:
<img width="494" alt="Screenshot 2023-01-25 at 19 33 11" src="https://user-images.githubusercontent.com/2527093/214613181-13771ba2-a1e3-427e-8a69-0e3036faff8d.png">
