### PR TITLE
feat: implement conversion to other formats

### DIFF
--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,49 +1,95 @@
-function extractConversation(data: any): any[] {
-    const current_node = data.current_node
+interface Message {
+    parent?: string
+    message?: {
+        author: {
+            role: string
+        }
+        create_time: number
+        content: {
+            parts: string[]
+        }
+    }
+}
+
+interface MessageMapping {
+    [key: string]: Message
+}
+
+interface ConversationData {
+    current_node: string
+    mapping: MessageMapping
+}
+
+interface TavernMessage {
+    name: string
+    is_user: boolean
+    is_name: boolean
+    send_date: number
+    mes: string
+    swipes: string[]
+    swipe_id: number
+}
+
+interface NameMessage {
+    user_name: string
+    character_name: string
+}
+
+interface OobaData {
+    internal: [string, string][]
+    visible: [string, string][]
+}
+
+function extractConversation(data: ConversationData): Message[] {
+    const currentNode = data.current_node
     const mapping = data.mapping
 
-    const messagesReversed: any[] = []
-    let node_id: any = current_node
+    const messagesReversed: Message[] = []
+    let nodeId: string | undefined = currentNode
 
-    while (node_id !== null && node_id !== undefined) {
-        const current_message = mapping[node_id]
-        messagesReversed.push(current_message)
-        node_id = current_message.parent
+    while (nodeId !== null && nodeId !== undefined) {
+        const currentMessage: Message = mapping[nodeId]
+        messagesReversed.push(currentMessage)
+        nodeId = currentMessage.parent
     }
 
     return messagesReversed.reverse()
 }
 
-function convertMessageToTavern(message_data: any): any | null {
-    if (!message_data.message) {
+function convertMessageToTavern(messageData: Message): TavernMessage | null {
+    if (!messageData.message) {
         return null
     }
 
-    const sender_role: string = message_data.message.author.role
-    if (sender_role === 'system') {
+    const senderRole: string = messageData.message.author.role
+    if (senderRole === 'system') {
         return null
     }
 
-    const is_assistant = sender_role === 'assistant'
-    const create_time = Number.parseInt(message_data.message.create_time, 10)
-    const text: string = message_data.message.content.parts[0]
+    const isAssistant = senderRole === 'assistant'
+    const createTime: number = messageData.message.create_time
+    const text: string = messageData.message.content.parts[0]
 
     return {
-        name: is_assistant ? 'Assistant' : 'You',
-        is_user: !is_assistant,
-        is_name: is_assistant,
-        send_date: create_time,
+        name: isAssistant ? 'Assistant' : 'You',
+        is_user: !isAssistant,
+        is_name: isAssistant,
+        send_date: createTime,
         mes: text,
         swipes: [text],
         swipe_id: 0,
     }
 }
 
-export function getTavernString(jsonData: any): string {
+function jsonlStringify(messageArray: any[]): string {
+    return messageArray.map((msg: any) => JSON.stringify(msg)).join('\n')
+}
+
+export function getTavernString(jsonData: ConversationData): string {
     // Takes the OAI JSON data as input, outputs the JSONL string
     const conversation = extractConversation(jsonData)
 
-    const convertedConvo: any[] = [{
+    const convertedConvo: (TavernMessage | NameMessage)[] = [{
         user_name: 'You',
         character_name: 'Assistant',
     }]
@@ -55,13 +101,12 @@ export function getTavernString(jsonData: any): string {
         }
     })
     // This _has_ to be stringified without adding any indentation, due to the JSONL format.
-    return convertedConvo.map(msg => JSON.stringify(msg)).join('\n')
+    return jsonlStringify(convertedConvo)
 }
 
-export function getOobaString(jsonData: any): string {
+export function getOobaString(jsonData: ConversationData): string {
     // Takes the OAI JSON data as input, outputs the serialized JSON
     const messages = extractConversation(jsonData)
-    const oobaData: any = {}
     const pairs: any[] = []
     let idx = 0
 
@@ -69,6 +114,11 @@ export function getOobaString(jsonData: any): string {
         const message = messages[idx]
         const nextMessage = messages[idx + 1]
         let role: string, text: string, nextRole: string, nextText: string
+
+        if (!message.message || !nextMessage.message) {
+            idx += 1
+            continue
+        }
 
         try {
             role = message.message.author.role
@@ -107,9 +157,10 @@ export function getOobaString(jsonData: any): string {
             idx += 1
         }
     }
-
-    oobaData.internal = pairs
-    oobaData.visible = JSON.parse(JSON.stringify(pairs))
+    const oobaData: OobaData = {
+        internal: pairs,
+        visible: JSON.parse(JSON.stringify(pairs)),
+    }
 
     if (oobaData.visible[0] && oobaData.visible[0][0] === '<|BEGIN-VISIBLE-CHAT|>') {
         oobaData.visible[0][0] = ''

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,0 +1,119 @@
+function extractConversation(data: any): any[] {
+    const current_node = data.current_node
+    const mapping = data.mapping
+
+    const messagesReversed: any[] = []
+    let node_id: any = current_node
+
+    while (node_id !== null && node_id !== undefined) {
+        const current_message = mapping[node_id]
+        messagesReversed.push(current_message)
+        node_id = current_message.parent
+    }
+
+    return messagesReversed.reverse()
+}
+
+function convertMessageToTavern(message_data: any): any | null {
+    if (!message_data.message) {
+        return null
+    }
+
+    const sender_role: string = message_data.message.author.role
+    if (sender_role === 'system') {
+        return null
+    }
+
+    const is_assistant = sender_role === 'assistant'
+    const create_time = Number.parseInt(message_data.message.create_time, 10)
+    const text: string = message_data.message.content.parts[0]
+
+    return {
+        name: is_assistant ? 'Assistant' : 'You',
+        is_user: !is_assistant,
+        is_name: is_assistant,
+        send_date: create_time,
+        mes: text,
+        swipes: [text],
+        swipe_id: 0,
+    }
+}
+
+export function getTavernString(jsonData: any): string {
+    // Takes the OAI JSON data as input, outputs the JSONL string
+    const conversation = extractConversation(jsonData)
+
+    const convertedConvo: any[] = [{
+        user_name: 'You',
+        character_name: 'Assistant',
+    }]
+
+    conversation.forEach((message) => {
+        const convertedMsg = convertMessageToTavern(message)
+        if (convertedMsg !== null) {
+            convertedConvo.push(convertedMsg)
+        }
+    })
+    // This _has_ to be stringified without adding any indentation, due to the JSONL format.
+    return convertedConvo.map(msg => JSON.stringify(msg)).join('\n')
+}
+
+export function getOobaString(jsonData: any): string {
+    // Takes the OAI JSON data as input, outputs the serialized JSON
+    const messages = extractConversation(jsonData)
+    const oobaData: any = {}
+    const pairs: any[] = []
+    let idx = 0
+
+    while (idx < messages.length - 1) {
+        const message = messages[idx]
+        const nextMessage = messages[idx + 1]
+        let role: string, text: string, nextRole: string, nextText: string
+
+        try {
+            role = message.message.author.role
+            text = message.message.content.parts[0]
+            nextRole = nextMessage.message.author.role
+            nextText = nextMessage.message.content.parts[0]
+        }
+        catch (error) {
+            idx += 1
+            continue
+        }
+
+        if (role === 'system') {
+            if (text !== '') {
+                pairs.push(['<|BEGIN-VISIBLE-CHAT|>', text])
+            }
+            idx += 1
+            continue
+        }
+
+        if (role === 'user') {
+            if (nextRole === 'assistant') {
+                pairs.push([text, nextText])
+                idx += 2
+                continue
+            }
+            else if (nextRole === 'user') {
+                pairs.push([text, ''])
+                idx += 1
+                continue
+            }
+        }
+
+        if (role === 'assistant') {
+            pairs.push(['', text])
+            idx += 1
+        }
+    }
+
+    oobaData.internal = pairs
+    oobaData.visible = JSON.parse(JSON.stringify(pairs))
+
+    if (oobaData.visible[0] && oobaData.visible[0][0] === '<|BEGIN-VISIBLE-CHAT|>') {
+        oobaData.visible[0][0] = ''
+    }
+
+    return JSON.stringify(oobaData, null, 2)
+}


### PR DESCRIPTION
As referenced in issue #210 

Added getOobaString and getTavernString to a new conversion.ts file in utils.

Both of these functions take the OAI JSON as input and return a string, ready to be downloaded, in the corresponding format.

getOobaString returns the format required by oobabooga's [text-generation-webui](https://github.com/oobabooga/text-generation-webui)

getTavernString returns the format required by [TavernAI](github.com/TavernAI/TavernAI) and derivatives (SillyTavern, Chub Venus, etc.)