### PR TITLE
Update image/HTML export colors to match ChatGPT UI

### DIFF
--- a/src/exporter/image.ts
+++ b/src/exporter/image.ts
@@ -31,8 +31,8 @@ export async function exportToPng(fileNameFormat: string) {
         style.textContent = `
         main [class^=\'react-scroll-to-bottom\'] > div > div,
         [data-testid^="conversation-turn-"] {
-                color: ${isDarkMode ? '#ececf1' : '#0f0f0f'};
-                background-color: ${isDarkMode ? 'rgb(52,53,65)' : '#fff'};
+                color: ${isDarkMode ? '#ececec' : '#0d0d0d'};
+                background-color: ${isDarkMode ? '#212121' : '#fff'};
             }
 
             pre {

--- a/src/template.html
+++ b/src/template.html
@@ -13,28 +13,28 @@
 
     <style>
         :root {
-            --tw-prose-code: #111827;
-            --tw-prose-hr: #e5e7eb;
-            --tw-prose-links: #111827;
-            --tw-prose-headings: #111827;
-            --tw-prose-quotes: #111827;
-            --tw-prose-counters: #6b7280;
-            --page-bg: #f7f7f8;
-            --page-text: #374151;
-            --th-borders: #4b5563;
+            --page-text: #0d0d0d;
+            --page-bg: #fff;
             --td-borders: #374151;
+            --th-borders: #4b5563;
+            --tw-prose-code: var(--page-text);
+            --tw-prose-counters: #9b9b9b;
+            --tw-prose-headings: var(--page-text);
+            --tw-prose-hr: rgba(0,0,0,.25);
+            --tw-prose-links: var(--page-text);
+            --tw-prose-quotes: var(--page-text);
             --meta-title: #616c77;
         }
 
         [data-theme="dark"] {
-            --tw-prose-code: #f9fafb;
-            --tw-prose-hr: #374151;
-            --tw-prose-links: #fff;
-            --tw-prose-headings: #fff;
-            --tw-prose-quotes: #f3f4f6;
-            --tw-prose-counters: #9ca3af;
-            --page-bg: rgba(52,53,65);
-            --page-text: #fff;
+            --page-text: #ececec;
+            --page-bg: #212121;
+            --tw-prose-code: var(--page-text);
+            --tw-prose-counters: #9b9b9b;
+            --tw-prose-headings: var(--page-text);
+            --tw-prose-hr: hsla(0,0%,100%,.25);
+            --tw-prose-links: var(--page-text);
+            --tw-prose-quotes: var(--page-text);
             --meta-title: #959faa;
         }
 

--- a/src/template.html
+++ b/src/template.html
@@ -22,8 +22,8 @@
             --page-bg: #f7f7f8;
             --page-text: #374151;
             --conversation-odd-bg: rgba(247,247,248);
-            --th-boarders: #4b5563;
-            --td-boarders: #374151;
+            --th-borders: #4b5563;
+            --td-borders: #374151;
             --meta-title: #616c77;
         }
 
@@ -290,7 +290,7 @@
         }
 
         table thead {
-            border-bottom-color: var(--th-boarders);
+            border-bottom-color: var(--th-borders);
             border-bottom-width: 1px;
         }
 
@@ -312,7 +312,7 @@
         }
 
         table tbody tr {
-            border-bottom-color: var(--td-boarders);
+            border-bottom-color: var(--td-borders);
             border-bottom-width: 1px;
         }
 

--- a/src/template.html
+++ b/src/template.html
@@ -21,7 +21,6 @@
             --tw-prose-counters: #6b7280;
             --page-bg: #f7f7f8;
             --page-text: #374151;
-            --conversation-odd-bg: rgba(247,247,248);
             --th-borders: #4b5563;
             --td-borders: #374151;
             --meta-title: #616c77;
@@ -36,7 +35,6 @@
             --tw-prose-counters: #9ca3af;
             --page-bg: rgba(52,53,65);
             --page-text: #fff;
-            --conversation-odd-bg: rgb(68,70,84);
             --meta-title: #959faa;
         }
 
@@ -381,10 +379,6 @@
 
         .conversation-item:first-of-type {
             border-top: 1px solid rgba(0,0,0,.1);
-        }
-
-        .conversation-item:nth-child(odd) {
-            background-color: var(--conversation-odd-bg);
         }
 
         .author {


### PR DESCRIPTION
This PR fixes https://github.com/pionxzh/chatgpt-exporter/issues/226.

Source used as reference for the new colors: https://cdn.oaistatic.com/_next/static/css/27480e870671f7ed.css

Example visual comparison:

# Light mode
## Ground truth screenshot
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/7eab44ca-6cfc-4435-bfb7-6574647ba129)

## HTML export (old)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/ba9ea881-0e0d-42c4-85a5-9576d38bb8a1)

## HTML export (new)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/2f50ce05-5948-4fda-9b4f-f248f36d8b85)

## Image export (old)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/2d3d4656-adc1-46da-9bb4-a7ccafa18fe3)

## Image export (new)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/f3d74101-f67e-469e-b69d-4b0ed24ee64c)

---

# Dark mode
## Ground truth screenshot
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/f6acef23-2275-41d5-8907-e1879c39dff2)

## HTML export (old)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/42803828-76f3-428b-a28f-1fb81f85e4c8)

### HTML export (new)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/f730ab29-f680-4b99-83c6-b96ac0f32718)

### Image export (old)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/217d685a-7e6b-4f6d-9afb-db7be079f5f3)

### Image export (new)
![0](https://github.com/pionxzh/chatgpt-exporter/assets/57649592/da6cbbfe-cf0b-41b0-a877-be574a26c74f)