### PR TITLE
fix: add @match for new ChatGPT domain with query parameter

### DIFF
--- a/dist/chatgpt.user.js
+++ b/dist/chatgpt.user.js
@@ -19,6 +19,7 @@
 // @match              https://chat.openai.com/share/*
 // @match              https://chat.openai.com/share/*/continue
 // @match              https://chatgpt.com/
+// @match              https://chatgpt.com/?oai-dm=1
 // @match              https://chatgpt.com/?model=*
 // @match              https://chatgpt.com/c/*
 // @match              https://chatgpt.com/g/*


### PR DESCRIPTION
Added @match for https://chatgpt.com/?oai-dm=1 to the Tampermonkey script manifest. This is to handle the new domain for ChatGPT, as the old domain https://chat.openai.com/ now redirects to the new address with the '?oai-dm=1' query parameter. The manifest already includes all variations of the new address except this one.