### PR TITLE
Fix Menu Button Visibility

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,26 +12,51 @@ main()
 
 function main() {
     onloadSafe(() => {
-        const container = document.createElement('div')
-        // to overlap on the list section
-        container.style.zIndex = '20'
-        render(<Menu container={container} />, container)
+        const container = document.createElement("div");
+        container.style.zIndex = "20";
+        D$4(/* @__PURE__ */ o$8(Menu, { container }), container);
 
-        const styleEl = document.createElement('style')
-        styleEl.id = 'sentinel-css'
-        document.head.append(styleEl)
+        const styleEl = document.createElement("style");
+        styleEl.id = "sentinel-css";
+        document.head.append(styleEl);
 
-        sentinel.on('nav', (nav) => {
-            const chatList = document.querySelector('nav > div.overflow-y-auto, nav > div.overflow-y-hidden')
-            if (chatList) {
-                chatList.after(container)
+        // Variable to store the interval ID
+        let menuInjectionInterval = null;
+
+        
+        /** Inject menu to the right of the profile button */
+        function injectMenu() {
+            const headerDiv = document.querySelector('div[class^="sticky top-0 p-3 mb-1.5 flex items-center justify-between"]');
+            if (!headerDiv) return;
+
+            const profileButtonDiv = headerDiv.querySelector('div[class^="flex items-center gap-2 pr-1 leading-[0]"]');
+            const menuExists = profileButtonDiv.contains(container);
+
+            if (profileButtonDiv && !menuExists) {
+                profileButtonDiv.appendChild(container);
+
+                if (menuInjectionInterval) {
+                    // Stop the periodic check once the menu is injected
+                    clearInterval(menuInjectionInterval);
+                    menuInjectionInterval = null;
+                }
             }
-            else {
-                // fallback to the bottom of the nav
-                nav.append(container)
-            }
-        })
+        }
 
+        // Initial injection
+        injectMenu();
+
+        // Watch for changes using sentinel
+        sentinel.on('div[class^="sticky top-0 p-3 mb-1.5 flex items-center justify-between"]', () => {
+            injectMenu();
+        });
+
+        // Start the periodic check using setInterval
+        menuInjectionInterval = setInterval(() => {
+            injectMenu();
+        }, 500);
+          
+          
         // Support for share page
         if (isSharePage()) {
             const continueUrl = `${location.href}/continue`

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,7 @@ function main() {
     onloadSafe(() => {
         const container = document.createElement("div");
         container.style.zIndex = "20";
-        D$4(/* @__PURE__ */ o$8(Menu, { container }), container);
+        (Menu, { container }), container);
 
         const styleEl = document.createElement("style");
         styleEl.id = "sentinel-css";
@@ -23,7 +23,6 @@ function main() {
         // Variable to store the interval ID
         let menuInjectionInterval = null;
 
-        
         /** Inject menu to the right of the profile button */
         function injectMenu() {
             const headerDiv = document.querySelector('div[class^="sticky top-0 p-3 mb-1.5 flex items-center justify-between"]');
@@ -55,8 +54,7 @@ function main() {
         menuInjectionInterval = setInterval(() => {
             injectMenu();
         }, 500);
-          
-          
+
         // Support for share page
         if (isSharePage()) {
             const continueUrl = `${location.href}/continue`

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,10 +32,9 @@ function main() {
             const menuExists = profileButtonDiv.contains(container);
 
             if (profileButtonDiv && !menuExists) {
-                profileButtonDiv.appendChild(container);
+                profileButtonDiv.insertBefore(container, profileButtonDiv.firstChild);
 
                 if (menuInjectionInterval) {
-                    // Stop the periodic check once the menu is injected
                     clearInterval(menuInjectionInterval);
                     menuInjectionInterval = null;
                 }

--- a/src/ui/Divider.tsx
+++ b/src/ui/Divider.tsx
@@ -1,1 +1,0 @@
-export const Divider = () => <div className="h-px bg-token-border-light"></div>

--- a/src/ui/Menu.tsx
+++ b/src/ui/Menu.tsx
@@ -9,7 +9,6 @@ import { exportToMarkdown } from '../exporter/markdown'
 import { exportToText } from '../exporter/text'
 import { useWindowResize } from '../hooks/useWindowResize'
 import { getHistoryDisabled } from '../page'
-import { Divider } from './Divider'
 import { ExportDialog } from './ExportDialog'
 import { FileCode, IconArrowRightFromBracket, IconCamera, IconCopy, IconJSON, IconMarkdown, IconSetting, IconZip } from './Icons'
 import { MenuItem } from './MenuItem'
@@ -222,7 +221,6 @@ function MenuInner({ container }: { container: HTMLDivElement }) {
                     </HoverCard.Content>
                 </Portal>
             </HoverCard.Root>
-            <Divider />
         </>
     )
 }

--- a/src/ui/MenuItem.tsx
+++ b/src/ui/MenuItem.tsx
@@ -49,7 +49,7 @@ export const MenuItem: FC<MenuItemProps> = ({ text, successText, disabled = fals
             transition-colors duration-200
             text-menu text-sm
             cursor-pointer
-            border border-menu ${className}`}
+            ${className}`}
             onClick={handleClick}
             onTouchStart={handleClick}
             disabled={disabled}


### PR DESCRIPTION
This pull request fixes the issue of the main menu button disappearing since ChatGPT moved the profile button to a new location. This PR implements a robust solution for relocating the menu button to the profile button `div`.

**Changes Made:**

* **Main Menu Button Placement:** The export menu button now resides as the first child of the profile button `div`. This visually groups it with the profile button.
* **Optimized Injection:** The `injectMenu()` function utilizes `setInterval` to actively check if the menu button already exists in the profile button `div`. If not, it injects it. The `setInterval` loop is immediately stopped after successful injection to minimize unnecessary checks and improve performance.
* **Minor Aesthetic Optimizations:** Since the menu button now shares a container with the profile button, the extra border and divider line have been removed for a cleaner look. 

**Testing:**

1. Tested these changes in MS Edge by updating the userscript manually.
2. Performed a hard refresh (Ctrl+Shift+R or Cmd+Shift+R) on ChatGPT to clear the cache and ensure a clean reload.
3. Confirmed the export menu button consistently appears next to the share chat and profile button in the header.

**Benefits:**

* **Improved Visibility:** The menu button is visible again after ChatGPT moved the profile button.
* **Improved Performance:** The optimized injection logic, including the `setInterval` termination, reduces unnecessary DOM manipulation for better performance.

**Screenshot**:
![image](https://github.com/user-attachments/assets/3df30c74-e6e0-4fcd-8401-edd3c5ecbf7c)

**Closing Issues**
This PR closes issue #251.