### PR TITLE
work on #261: avoid hang

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -318,8 +318,8 @@ async function fetchImageFromPointer(uri: string) {
 /** avoid errors in parsing multimodal parts we don't understand */
 async function replaceImageAssets(conversation: ApiConversation): Promise<void> {
     const isMultiModalInputImage = (part: any): part is MultiModalInputImage => {
-        return typeof part === 'object' && part !== null && 'asset_pointer' in part &&
-               typeof part.asset_pointer === 'string' && part.asset_pointer.startsWith('file-service://')
+        return typeof part === 'object' && part !== null && 'asset_pointer' in part
+               && typeof part.asset_pointer === 'string' && part.asset_pointer.startsWith('file-service://')
     }
 
     const imageAssets = Object.values(conversation.mapping).flatMap((node) => {


### PR DESCRIPTION
See #261 for the situation. This PR avoids errors caused by multimodal parts we don't understand.

It does NOT add any functionality that understands advanced voice mode parts. Perhaps that should be broken out of #261 into a separate enhancement request.

I have tested this code under the same conditions as #261, and it doesn't hang anymore. The affected conversations are outputted with sections like this instead:

```markdown
[Unsupported multimodal content]

![image](sediment://file_bade9197e86bd4dc6d01c2042690bd1dbade9197e86bd4dc6d01c2042690bd1dbade9197e86bd4dc6d01c2042690bd1d)
```