### PR TITLE
fix: fixed user conversations disappearing when exporting screenshots

### DIFF
--- a/src/exporter/image.ts
+++ b/src/exporter/image.ts
@@ -71,18 +71,21 @@ export async function exportToPng(fileNameFormat: string) {
         })
     }
 
-    // hide buttons
-    const buttonWrappers = document.querySelectorAll<HTMLDivElement>('main .flex.empty\\:hidden')
-    buttonWrappers.forEach((wrapper) => {
-        if (!wrapper.querySelector('button')) return
-        // ignore codeblock
-        if (wrapper.closest('pre')) return
-
+    // hide switch context button
+    const switchContextBuuton1 = thread.querySelectorAll('div.mb-2.flex.gap-3.empty\\:hidden.mr-1.flex-row-reverse')
+    if (switchContextBuuton1) {
         effect.add(() => {
-            wrapper.style.display = 'none'
-            return () => wrapper.style.display = ''
+            switchContextBuuton1.forEach(a => a.classList.add('hidden'))
+            return () => switchContextBuuton1.forEach(a => a.classList.remove('hidden'))
         })
-    })
+    }
+    const switchContextBuuton2 = thread.querySelectorAll('div.mb-2.flex.gap-3.empty\\:hidden.-ml-2')
+    if (switchContextBuuton2) {
+        effect.add(() => {
+            switchContextBuuton2.forEach(a => a.classList.add('hidden'))
+            return () => switchContextBuuton2.forEach(a => a.classList.remove('hidden'))
+        })
+    }
 
     // hide code block copy button
     const copyButtons = thread.querySelectorAll('pre button')


### PR DESCRIPTION
I found that when exporting images, user messages get lost, for example:

Original:
![image](https://github.com/user-attachments/assets/2eb98df1-e5e5-47b8-9b3f-714f5fe2bc3c)

Exported result:
![image](https://github.com/user-attachments/assets/7717a902-3933-46d2-ab87-d84a65336bd7)

I looked at the code and found that [here](https://github.com/pionxzh/chatgpt-exporter/blob/eccd564ce2338ded94af17a05c5fe9830fa7fa1a/src/exporter/image.ts#L75), the user conversation is hidden.

I'm not sure if this part of the code is intended to remove the "Previous" and "Next" buttons, but I found that after I removed this part, those buttons appeared.
![image](https://github.com/user-attachments/assets/fe7de991-59ea-4e7c-aeb5-89f95c12ac33)

So I added a piece of logic to remove these buttons.