### PR TITLE
Fix citation footnote generation and suppress 'thoughts'

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -50,7 +50,7 @@ export interface Citation {
 }
 
 export interface ContentReference {
-    type: 'grouped_webpages' & (string & {})
+    type: 'grouped_webpages' | 'sources_footnote' | 'nav_list' & (string & {})
     /** The text that was matched in the content, e.g., "citeturn0search3" */
     matched_text?: string
     start_idx: number

--- a/src/exporter/markdown.ts
+++ b/src/exporter/markdown.ts
@@ -251,19 +251,30 @@ function transformContentReferences(
     for (const ref of sortedRefs) {
         if (!ref.matched_text) continue
 
-        // Get URL and title from items array (new format) or direct fields
-        const item = ref.items?.[0]
-        const url = item?.url || ref.url
-        const title = item?.title || ref.title
+        // For some reason, the matched_text contains non-breaking spaces but the content doesn't!
+        const matchedText = ref.matched_text.replaceAll(/\s/gu, ' ')
 
-        if (!url) continue
+        switch (ref.type) {
+            case 'sources_footnote':
+                break
+            case 'nav_list':
+                output = output.replaceAll(matchedText, ref.alt || '')
+                break
+            default: {
+                // Get URL and title from items array (new format) or direct fields
+                const item = ref.items?.[0]
+                const url = item?.url || ref.url
+                const title = item?.title || ref.title
 
-        // Replace all occurrences of this matched_text
-        if (output.includes(ref.matched_text)) {
-            usedRefs.push({ url, title: title || url })
-            const refIndex = usedRefs.length
-            // Use global replace in case the same citation appears multiple times
-            output = output.split(ref.matched_text).join(`[^${refIndex}]`)
+                if (!url) continue
+
+                // Replace all occurrences of this matched_text
+                if (output.includes(ref.matched_text)) {
+                    usedRefs.push({ url, title: title || url })
+                    const refIndex = usedRefs.length
+                    output = output.replaceAll(matchedText, `[^${refIndex}]`)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue I was seeing where citations were not being properly converted to footnotes in the Markdown output. It also suppresses **Unsupported Content** blocks that were coming from `thoughts` and `reasoning_recap` entities.

If you have better ideas on how to address this, feel free to simply use it for "inspiration". I just figured this might be more helpful than simply opening an issue.