### PR TITLE
fix: improve content reference handling for citations and entities

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -50,7 +50,7 @@ export interface Citation {
 }
 
 export interface ContentReference {
-    type: 'grouped_webpages' | 'sources_footnote' | 'nav_list' & (string & {})
+    type: 'grouped_webpages' | 'sources_footnote' | 'nav_list' | 'alt_text' & (string & {})
     /** The text that was matched in the content, e.g., "citeturn0search3" */
     matched_text?: string
     start_idx: number
@@ -62,6 +62,12 @@ export interface ContentReference {
         title: string
         url: string
         attribution?: string
+        /** Additional sources for multi-citations */
+        supporting_websites?: Array<{
+            title: string
+            url: string
+            attribution?: string
+        }>
     }>
     // Legacy fields (may still be present in some responses)
     url?: string

--- a/src/exporter/text.ts
+++ b/src/exporter/text.ts
@@ -175,20 +175,27 @@ function transformContentReferences(
 
     const sortedRefs = [...contentRefs].sort((a, b) => (b.matched_text?.length || 0) - (a.matched_text?.length || 0))
 
+    // Normalize unicode variants (non-breaking spaces, non-breaking hyphens) to regular ASCII
+    const normalize = (s: string) => s
+        .replaceAll(/[\u00A0\u202F\u2007\u2060]/gu, ' ')
+        .replaceAll(/[\u2010-\u2015\u2212]/gu, '-')
+
+    let output = normalize(input)
+
     for (const ref of sortedRefs) {
         if (!ref.matched_text) continue
 
-        // For some reason, the matched_text contains non-breaking spaces but the content doesn't!
-        const matchedText = ref.matched_text.replaceAll(/\s/gu, ' ')
+        const matchedText = normalize(ref.matched_text)
 
         switch (ref.type) {
             case 'sources_footnote':
                 break
             default:
-                input = input.replaceAll(matchedText, '')
+                // Use ref.alt which contains display text (links won't render in plain text)
+                output = output.replaceAll(matchedText, ref.alt || '')
         }
     }
-    return input
+    return output
 }
 
 /**


### PR DESCRIPTION
Sorry about including the build output in my previous PR! I'm opening this one to address a few more issues I ran in to:

- Add support for `alt_text` content reference type (entity mentions)
- Fix Unicode normalization to include non-breaking hyphens and preserve newlines
- Render citations as inline links instead of footnotes
- Include all sources for multi-citations
- Fix HTML exporter to retain links instead of stripping them

This does change Markdown footnotes to inline links, but this better matches the ChatGPT output and simplifies that part of the code, especially with needing to handle multiple citations.

As before, just trying to be helpful instead of opening issues!