### PR TITLE
fix: skip hidden tool messages in exports

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -707,14 +707,13 @@ export function shouldSkipMessageInExport(message?: ConversationNodeMessage): bo
         const hasExecutionImages = message.content.content_type === 'execution_output'
             && !!message.metadata?.aggregate_result?.messages?.some(msg => msg.message_type === 'image')
 
-        const hasDalleImage = message.content.content_type === 'multimodal_text'
+        const hasMultimodalImage = message.content.content_type === 'multimodal_text'
             && message.content.parts.some((part) => {
                 return typeof part !== 'string'
                     && part.content_type === 'image_asset_pointer'
-                    && !!part.metadata?.dalle
             })
 
-        if (!hasExecutionImages && !hasDalleImage) {
+        if (!hasExecutionImages && !hasMultimodalImage) {
             return true
         }
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -689,6 +689,39 @@ export interface ConversationResult {
     projectId?: string
 }
 
+export function shouldSkipMessageInExport(message?: ConversationNodeMessage): boolean {
+    if (!message || !message.content) return true
+
+    // ChatGPT is talking to tool
+    if (message.recipient !== 'all') return true
+
+    // Skip "thinking" content (hidden reasoning steps from thinking models)
+    if (message.content.content_type === 'thoughts') return true
+    if (message.content.content_type === 'reasoning_recap') return true
+
+    // Skip messages marked as visually hidden (e.g., internal system prompts)
+    if (message.metadata?.is_visually_hidden_from_conversation) return true
+
+    // Skip tool's intermediate message.
+    if (message.author.role === 'tool') {
+        const hasExecutionImages = message.content.content_type === 'execution_output'
+            && !!message.metadata?.aggregate_result?.messages?.some(msg => msg.message_type === 'image')
+
+        const hasDalleImage = message.content.content_type === 'multimodal_text'
+            && message.content.parts.some((part) => {
+                return typeof part !== 'string'
+                    && part.content_type === 'image_asset_pointer'
+                    && !!part.metadata?.dalle
+            })
+
+        if (!hasExecutionImages && !hasDalleImage) {
+            return true
+        }
+    }
+
+    return false
+}
+
 const ModelMapping: { [key in ModelSlug]: string } & { [key: string]: string } = {
     'text-davinci-002-render-sha': 'GPT-3.5',
     'text-davinci-002-render-paid': 'GPT-3.5',
@@ -773,6 +806,8 @@ function extractConversationResult(conversationMapping: Record<string, Conversat
             && node.message?.content.content_type !== 'model_editable_context'
             // Skip user custom instructions
             && node.message?.content.content_type !== 'user_editable_context'
+            // Skip hidden/tool-only messages that should not appear in exported output
+            && !shouldSkipMessageInExport(node.message)
         ) {
             result.unshift(node)
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -199,7 +199,7 @@ interface MultiModalAudioTranscription {
 export interface ConversationNodeMessage {
     author: {
         role: AuthorRole
-        name?: 'browser' | 'python' & (string & {})
+        name?: 'browser' | 'python' | 'file_search' & (string & {})
         metadata: unknown
     }
     content: {
@@ -704,6 +704,8 @@ export function shouldSkipMessageInExport(message?: ConversationNodeMessage): bo
 
     // Skip tool's intermediate message.
     if (message.author.role === 'tool') {
+        if (message.author.name === 'file_search') return true
+
         const hasExecutionImages = message.content.content_type === 'execution_output'
             && !!message.metadata?.aggregate_result?.messages?.some(msg => msg.message_type === 'image')
 

--- a/src/exporter/html.ts
+++ b/src/exporter/html.ts
@@ -1,5 +1,5 @@
 import JSZip from 'jszip'
-import { fetchConversation, getCurrentChatId, processConversation } from '../api'
+import { fetchConversation, getCurrentChatId, processConversation, shouldSkipMessageInExport } from '../api'
 import { KEY_TIMESTAMP_24H, KEY_TIMESTAMP_ENABLED, KEY_TIMESTAMP_HTML, baseUrl } from '../constants'
 import i18n from '../i18n'
 import { checkIfConversationStarted, getUserAvatar } from '../page'
@@ -80,31 +80,7 @@ function conversationToHtml(conversation: ConversationResult, avatar: string, me
     const conversationHtml = conversationNodes.map(({ message }) => {
         if (!message || !message.content) return null
 
-        // ChatGPT is talking to tool
-        if (message.recipient !== 'all') return null
-
-        // Skip "thinking" content (hidden reasoning steps from thinking models)
-        if (message.content.content_type === 'thoughts') return null
-        if (message.content.content_type === 'reasoning_recap') return null
-
-        // Skip messages marked as visually hidden (e.g., internal system prompts)
-        if (message.metadata?.is_visually_hidden_from_conversation) return null
-
-        // Skip tool's intermediate message.
-        if (message.author.role === 'tool') {
-            if (
-                // HACK: we special case the content_type 'multimodal_text' here because it is used by
-                // the dalle tool to return the image result, and we do want to show that.
-                message.content.content_type !== 'multimodal_text'
-                // Code execution result with image
-            && !(
-                message.content.content_type === 'execution_output'
-                && message.metadata?.aggregate_result?.messages?.some(msg => msg.message_type === 'image')
-            )
-            ) {
-                return null
-            }
-        }
+        if (shouldSkipMessageInExport(message)) return null
 
         const author = transformAuthor(message.author)
         const model = message?.metadata?.model_slug === 'gpt-4' ? 'GPT-4' : 'GPT-3'

--- a/src/exporter/markdown.ts
+++ b/src/exporter/markdown.ts
@@ -1,5 +1,5 @@
 import JSZip from 'jszip'
-import { fetchConversation, getCurrentChatId, processConversation } from '../api'
+import { fetchConversation, getCurrentChatId, processConversation, shouldSkipMessageInExport } from '../api'
 import { KEY_TIMESTAMP_24H, KEY_TIMESTAMP_ENABLED, KEY_TIMESTAMP_MARKDOWN, baseUrl } from '../constants'
 import i18n from '../i18n'
 import { checkIfConversationStarted } from '../page'
@@ -96,31 +96,7 @@ function conversationToMarkdown(conversation: ConversationResult, metaList?: Exp
     const content = conversationNodes.map(({ message }) => {
         if (!message || !message.content) return null
 
-        // ChatGPT is talking to tool
-        if (message.recipient !== 'all') return null
-
-        // Skip "thinking" content (hidden reasoning steps from thinking models)
-        if (message.content.content_type === 'thoughts') return null
-        if (message.content.content_type === 'reasoning_recap') return null
-
-        // Skip messages marked as visually hidden (e.g., internal system prompts)
-        if (message.metadata?.is_visually_hidden_from_conversation) return null
-
-        // Skip tool's intermediate message.
-        if (message.author.role === 'tool') {
-            if (
-                // HACK: we special case the content_type 'multimodal_text' here because it is used by
-                // the dalle tool to return the image result, and we do want to show that.
-                message.content.content_type !== 'multimodal_text'
-                // Code execution result with image
-            && !(
-                message.content.content_type === 'execution_output'
-                && message.metadata?.aggregate_result?.messages?.some(msg => msg.message_type === 'image')
-            )
-            ) {
-                return null
-            }
-        }
+        if (shouldSkipMessageInExport(message)) return null
 
         const timestamp = message?.create_time ?? ''
         const showTimestamp = enableTimestamp && timeStampMarkdown && timestamp

--- a/src/exporter/text.ts
+++ b/src/exporter/text.ts
@@ -1,4 +1,4 @@
-import { fetchConversation, getCurrentChatId, processConversation } from '../api'
+import { fetchConversation, getCurrentChatId, processConversation, shouldSkipMessageInExport } from '../api'
 import i18n from '../i18n'
 import { checkIfConversationStarted } from '../page'
 import { copyToClipboard } from '../utils/clipboard'
@@ -34,31 +34,7 @@ const LatexRegex = /(\s\$\$.+\$\$\s|\s\$.+\$\s|\\\[.+\\\]|\\\(.+\\\))|(^\$$[\S\s
 function transformMessage(message?: ConversationNodeMessage) {
     if (!message || !message.content) return null
 
-    // ChatGPT is talking to tool
-    if (message.recipient !== 'all') return null
-
-    // Skip "thinking" content (hidden reasoning steps from thinking models)
-    if (message.content.content_type === 'thoughts') return null
-    if (message.content.content_type === 'reasoning_recap') return null
-
-    // Skip messages marked as visually hidden (e.g., internal system prompts)
-    if (message.metadata?.is_visually_hidden_from_conversation) return null
-
-    // Skip tool's intermediate message.
-    if (message.author.role === 'tool') {
-        if (
-            // HACK: we special case the content_type 'multimodal_text' here because it is used by
-            // the dalle tool to return the image result, and we do want to show that.
-            message.content.content_type !== 'multimodal_text'
-            // Code execution result with image
-            && !(
-                message.content.content_type === 'execution_output'
-                && message.metadata?.aggregate_result?.messages?.some(msg => msg.message_type === 'image')
-            )
-        ) {
-            return null
-        }
-    }
+    if (shouldSkipMessageInExport(message)) return null
 
     const author = transformAuthor(message.author)
     let content = transformContent(message.content, message.metadata)

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,3 +1,4 @@
+import { shouldSkipMessageInExport } from '../api'
 import { jsonlStringify, nonNullable } from './utils'
 import type { ConversationNode, ConversationResult } from '../api'
 
@@ -22,7 +23,7 @@ interface OobaData {
 }
 
 function convertMessageToTavern(node: ConversationNode): TavernMessage | null {
-    if (!node.message || node.message.content.content_type !== 'text') {
+    if (!node.message || shouldSkipMessageInExport(node.message) || node.message.content.content_type !== 'text') {
         return null
     }
 
@@ -56,7 +57,11 @@ export function convertToTavern(conversation: ConversationResult): string {
 
 export function convertToOoba(conversation: ConversationResult): string {
     const pairs: [string, string][] = []
-    const messages = conversation.conversationNodes.filter(node => node.message?.author.role !== 'tool' && node.message?.content.content_type === 'text')
+    const messages = conversation.conversationNodes.filter((node) => {
+        return !!node.message
+            && !shouldSkipMessageInExport(node.message)
+            && node.message.content.content_type === 'text'
+    })
 
     let idx = 0
     while (idx < messages.length - 1) {


### PR DESCRIPTION
## Problem
Some exported conversations include hidden tool content that is not visible in the ChatGPT UI.

In my use case,I uploaded a paper, asked some questions about it, and then exported the conversation using the Greasyfork script from ChatGPT Exporter.

In the exported HTML and Markdown files, I found a HUGE amount of the paper's full text, even though that content is not visible in the official ChatGPT conversation view.

After looking into it further, the tool involved appears to be `file_search`. I'm not fully sure whether exporting this content is intended behavior, but when the exported HTML or Markdown becomes this large, it becomes very difficult to read or use effectively. A screenshot is attached below.

Because of that, I decided to try a minimal fix and submit this PR.

## Summary
- centralize export filtering for hidden and tool-only messages
- skip visually hidden and non-conversation tool messages in exports
- preserve image-producing tool outputs such as DALL·E image results and execution outputs with images

## Testing
- pnpm run lint
- pnpm run test
- pnpm run build

## Reproduction
- reproduced the issue with exported conversations that included hidden `file_search` content such as `Make sure to include ...` and `#### Plugin (file_search):`
- verified that the exported Markdown and HTML no longer include those hidden tool messages

## Related
- no matching issue found
- closest related issue: #222

> Thanks again for maintaining and open-sourcing this project :-)

<img width="783" height="449" alt="4f3e6c5f-383e-4a01-aa92-03c40b4e7c1e" src="https://github.com/user-attachments/assets/421627d2-be08-42ec-ba8c-175607ac2cd7" />

<img width="898" height="796" alt="image" src="https://github.com/user-attachments/assets/7d4187fe-9c2a-40d7-851e-4087d4e9b446" />

