### PR TITLE
docs: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 <div align="center">
 
-<img src="https://api.star-history.com/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Star History Chart" valign="middle">
+<img src="https://star-history.dera.page/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Star History Chart" valign="middle">
 
 </div>

--- a/README_FR.md
+++ b/README_FR.md
@@ -256,6 +256,6 @@ Voir [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 <div align="center">
 
-<img src="https://api.star-history.com/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Graphique de l'historique des étoiles" valign="middle">
+<img src="https://star-history.dera.page/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Graphique de l'historique des étoiles" valign="middle">
 
 </div>

--- a/README_ID.md
+++ b/README_ID.md
@@ -265,6 +265,6 @@ Lihat [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 <div align="center">
 
-<img src="https://api.star-history.com/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Star History Chart" valign="middle">
+<img src="https://star-history.dera.page/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Star History Chart" valign="middle">
 
 </div>

--- a/README_KR.md
+++ b/README_KR.md
@@ -259,6 +259,6 @@ API `https://chat.openai.com/backend-api/conversation/[id]` 에서 얻은 원시
 
 <div align="center">
 
-<img src="https://api.star-history.com/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="별 기록 차트" valign="middle">
+<img src="https://star-history.dera.page/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="별 기록 차트" valign="middle">
 
 </div>

--- a/README_TR.md
+++ b/README_TR.md
@@ -257,6 +257,6 @@ Sol alt köşedeki açılır menüden dışa aktarma formatınızı seçin. Aşa
 
 <div align="center">
 
-<img src="https://api.star-history.com/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Yıldız Geçmişi Grafiği" valign="middle">
+<img src="https://star-history.dera.page/svg?repos=pionxzh/chatgpt-exporter&type=Date" width="600" height="400" alt="Yıldız Geçmişi Grafiği" valign="middle">
 
 </div>


### PR DESCRIPTION
The star history chart in the README has been broken for a while due to upstream stargazer API restrictions that no longer work without an API token. This restores a working star history chart by pointing it to a dependable alternative provider. The same fix has already been adopted by many other projects, so the chart remains accurate and stays up to date.